### PR TITLE
The final scratch stage is unnecessary

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -5,12 +5,12 @@ set -euo pipefail
 main() {
   export BUILDKIT_PROGRESS=plain
   export PROGRESS_NO_TRUNC=1
+
   docker build . \
     --target build-output \
     --output build
 
-  docker build . \
-    --output build/libs
+  docker build .
 }
 
 main "$@"


### PR DESCRIPTION
Also, gradle.properties changing doesn;t need to invalidate the gradle
cached gradle installation.
